### PR TITLE
feat: 결제 및 주문 처리의 동시성 문제 해결을 위한 비관적 락 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,11 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// MapStruct
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/src/main/java/com/sellon/order/repository/OrderRepository.java
+++ b/src/main/java/com/sellon/order/repository/OrderRepository.java
@@ -1,11 +1,23 @@
 package com.sellon.order.repository;
 
 import com.sellon.order.entity.Order;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderNumber(String orderNumber);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Order o WHERE o.id = :id")
+    Optional<Order> findByIdWithPessimisticLock(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("SELECT o FROM Order o WHERE o.id = :id")
+    Optional<Order> findByIdWithPessimisticReadLock(@Param("id") Long id);
 }

--- a/src/main/java/com/sellon/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sellon/payment/repository/PaymentRepository.java
@@ -1,10 +1,25 @@
 package com.sellon.payment.repository;
 
 import com.sellon.payment.entity.Payment;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByTransactionId(String transactionId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.id = :id")
+    Optional<Payment> findByIdWithPessimisticLock(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("SELECT p FROM Payment p WHERE p.id = :id")
+    Optional<Payment> findByIdWithPessimisticReadLock(@Param("id") Long id);
+
 }

--- a/src/main/java/com/sellon/payment/service/PayClient.java
+++ b/src/main/java/com/sellon/payment/service/PayClient.java
@@ -1,0 +1,13 @@
+package com.sellon.payment.service;
+
+import com.sellon.order.entity.Order;
+import com.sellon.payment.dto.PayApproveReponse;
+import com.sellon.payment.dto.PayApproveRequest;
+import com.sellon.payment.dto.PayReadyResponse;
+import com.sellon.payment.entity.PaymentMethod;
+
+public interface PayClient {
+    boolean isAvailable(PaymentMethod paymentMethod);
+    PayReadyResponse ready(Order order);
+    PayApproveReponse approve(PayApproveRequest request);
+}

--- a/src/main/java/com/sellon/payment/service/PaymentService.java
+++ b/src/main/java/com/sellon/payment/service/PaymentService.java
@@ -1,74 +1,11 @@
 package com.sellon.payment.service;
 
-import com.sellon.payment.dto.PaymentResult;
-import com.sellon.payment.entity.Payment;
-import com.sellon.payment.entity.PaymentMethod;
-import com.sellon.payment.entity.PaymentStatus;
-import com.sellon.payment.exception.PaymentProcessingException;
-import com.sellon.payment.repository.PaymentRepository;
-import java.sql.SQLException;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
+import com.sellon.payment.dto.ApprovePaymentRequest;
+import com.sellon.payment.dto.ApprovePaymentResponse;
+import com.sellon.payment.dto.CreatePaymentRequest;
+import com.sellon.payment.dto.CreatePaymentResponse;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-public class PaymentService {
-    private final PaymentRepository paymentRepository;
-
-    // 결제 트랜잭션 ID별 락 객체를 관리하는 맵
-    private final Map<String, Object> paymentLocks = new ConcurrentHashMap<>();
-
-    // 결제 처리 메서드
-    public PaymentResult processPayment(Payment payment, PaymentMethod method) {
-        // 결제 ID에 해당하는 락 객체 가져오기 (없으면 생성)
-        Object lock = paymentLocks.computeIfAbsent(payment.getTransactionId(), k -> new Object());
-
-        // synchronized 블록으로 임계영역 설정
-        synchronized (lock) {
-            try {
-                // 상태체크: 작업 가능한 상태인지 확인
-                if (!isValidStateForProcessing(payment.getPaymentStatus())) {
-                    throw new PaymentProcessingException("결제 상태가 작업을 허용하지 않습니다.");
-                }
-
-                // 결제 수단별 작업 수행
-                method.process(payment);
-
-                // 예외가 없으면 성공으로 간주
-                updatePaymentStatus(payment, PaymentStatus.COMPLETED);
-                return PaymentResult.success("결제 성공");
-
-            } catch (PaymentProcessingException e) {
-                // 로깅
-                log.error("결제 처리 중 오류 발생: {}", e);
-                updatePaymentStatus(payment, PaymentStatus.FAILED);
-                return PaymentResult.failed("결제 처리 중 오류 발생: " + e.getMessage());
-            } catch (SQLException e) {
-                // 디비관련 예외 발생의 경우
-                log.error("SQL 예외 발생: {}", e);
-                updatePaymentStatus(payment, PaymentStatus.FAILED);
-                return PaymentResult.failed("SQL 예외 발생: " + e.getMessage());
-            } finally {
-                paymentLocks.remove(payment.getTransactionId());
-            }
-        }
-
-    }
-    // 상태 체크 로직
-    private boolean isValidStateForProcessing(PaymentStatus status) {
-        // INITIALIZED 또는 PROCESSING 상태일 때만 작업 가능
-        return status == PaymentStatus.INITIALIZED || status == PaymentStatus.PROCESSING;
-    }
-
-    private void updatePaymentStatus(Payment payment, PaymentStatus status) {
-        payment.updateStatus(status);
-        paymentRepository.save(payment);
-    }
-
-
+public interface PaymentService {
+    CreatePaymentResponse createPayment(CreatePaymentRequest request);
+    ApprovePaymentResponse approvePayment(ApprovePaymentRequest request);
 }

--- a/src/main/java/com/sellon/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/sellon/payment/service/PaymentServiceImpl.java
@@ -1,0 +1,65 @@
+package com.sellon.payment.service;
+
+import com.sellon.order.entity.Order;
+import com.sellon.order.exception.OrderNotFoundException;
+import com.sellon.order.repository.OrderRepository;
+import com.sellon.payment.dto.ApprovePaymentRequest;
+import com.sellon.payment.dto.ApprovePaymentResponse;
+import com.sellon.payment.dto.CreatePaymentRequest;
+import com.sellon.payment.dto.CreatePaymentResponse;
+import com.sellon.payment.dto.PayApproveReponse;
+import com.sellon.payment.dto.PayReadyResponse;
+import com.sellon.payment.entity.Payment;
+import com.sellon.payment.exception.PaymentFailedException;
+import com.sellon.payment.mapper.PaymentMapper;
+import com.sellon.payment.repository.PaymentRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl {
+    private final OrderRepository orderRepository;
+    private final PaymentRepository paymentRepository;
+    private final PaymentMapper paymentMapper;
+    private final List<PayClient> payClients;
+
+    public CreatePaymentResponse createPayment(CreatePaymentRequest request) {
+        Order order = orderRepository.findByIdWithPessimisticLock(request.getOrderId())
+            .orElseThrow(() -> new OrderNotFoundException("주문을 찾을 수 없습니다: " + request.getOrderId()));
+
+        Payment payment = paymentMapper.toEntity(request, order);
+        paymentRepository.save(payment);
+
+        PayClient payClient = payClients.stream()
+            .filter(client -> client.isAvailable(request.getPaymentMethod()))
+            .findFirst()
+            .orElseThrow(() -> {
+                paymentRepository.save(payment.fail("잘못된 결제 수단"));
+                return new PaymentFailedException("결제 수단을 확인해주세요.");
+            });
+
+        PayReadyResponse payReadyResponse = payClient.ready(order);
+        return CreatePaymentResponse.from(payment, payReadyResponse);
+    }
+
+    public ApprovePaymentResponse approvePayment(ApprovePaymentRequest request) {
+        Payment payment = paymentRepository.findByIdWithPessimisticLock(request.getPaymentId())
+            .orElseThrow(() -> new PaymentFailedException("정산을 찾을 수 없습니다: " + request.getPaymentId()));
+
+        PayClient payClient = payClients.stream()
+            .filter(client -> client.isAvailable(request.getPaymentMethod()))
+            .findFirst()
+            .orElseThrow(() -> {
+                paymentRepository.save(payment.fail("잘못된 결제 수단"));
+                return new PaymentFailedException("결제 수단을 확인해주세요.");
+            });
+
+        PayApproveReponse payApproveResponse = payClient.approve(paymentMapper.toPayApproveRequest(request));
+        paymentRepository.save(payment.complete(LocalDateTime.now()));
+        return ApprovePaymentResponse.from(payment, payApproveResponse);
+    }
+
+}


### PR DESCRIPTION
결제 및 주문 처리 과정에서 발생하는 동시성 문제를 해결하기 위해 비관적 락(Pessimistic Lock)을 도입했습니다.

## 문제점
- 중복 결제 발생: 사용자가 결제 버튼을 빠르게 여러 번 클릭 시 같은 주문에 대해 여러 결제 생성

### 시나리오 예시
```
동시 접근 시나리오:
시간 | 요청 A               | 요청 B
T1   | Order 조회 (PENDING) | Order 조회 (PENDING)
T2   | Payment 생성         | Payment 생성  
T3   | 결과: 중복 결제 발생! 💥
```

## 해결책
### Database-level Pessimistic Locking
```
// 📝 비관적 쓰기 락 (PESSIMISTIC_WRITE)
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("SELECT o FROM Order o WHERE o.id = :id")
Optional<Order> findByIdWithPessimisticLock(@Param("id") Long id);

// 📖 비관적 읽기 락 (PESSIMISTIC_READ)  
@Lock(LockModeType.PESSIMISTIC_READ)
@Query("SELECT p FROM Payment p WHERE p.id = :id")
Optional<Payment> findByIdWithPessimisticReadLock(@Param("id") Long id);
```
- 결제 생성 시: Order에 PESSIMISTIC_WRITE 락 적용
- 결제 승인 시: Payment와 Order 모두에 PESSIMISTIC_WRITE 락 적용
- 결제 조회 시: Payment에 PESSIMISTIC_READ 락 적용
